### PR TITLE
Diagnose and fix branding package generation

### DIFF
--- a/DEPLOYMENT_FIX.md
+++ b/DEPLOYMENT_FIX.md
@@ -1,0 +1,82 @@
+# Fix for "Generate Branding Package" Error
+
+## Problem
+The application is failing with a `PGRST204` error indicating that the `brand_tone` column is missing from the `projects` table in the Supabase database.
+
+## Root Cause
+The database schema is out of sync. The application code expects a `brand_tone` column in the `projects` table, but this column doesn't exist in the deployed database.
+
+## Solution
+
+### Option 1: Fix the Database Schema (Recommended)
+
+1. **Go to your Supabase project dashboard**
+2. **Navigate to the SQL Editor**
+3. **Run the following SQL script:**
+
+```sql
+-- Check if the column exists
+SELECT column_name 
+FROM information_schema.columns 
+WHERE table_name = 'projects' 
+AND column_name = 'brand_tone';
+
+-- Add the brand_tone column if it doesn't exist
+ALTER TABLE projects 
+ADD COLUMN IF NOT EXISTS brand_tone TEXT NOT NULL DEFAULT 'professional';
+
+-- Remove the default constraint for flexibility
+ALTER TABLE projects 
+ALTER COLUMN brand_tone DROP DEFAULT;
+
+-- Verify the column was added
+SELECT column_name, data_type, is_nullable, column_default
+FROM information_schema.columns 
+WHERE table_name = 'projects' 
+AND column_name = 'brand_tone';
+
+-- Refresh the schema cache
+NOTIFY pgrst, 'reload schema';
+```
+
+4. **Redeploy your application on Railway** (this will pick up the code changes that handle the column gracefully)
+
+### Option 2: Alternative Database Setup
+
+If you need to recreate the entire database schema, run the complete setup script from `database-setup.sql`:
+
+```sql
+-- Run the entire contents of database-setup.sql in your Supabase SQL editor
+```
+
+## Code Changes Made
+
+The following changes have been implemented to make the application more robust:
+
+1. **API Endpoint (`app/api/generate-branding/route.ts`)**:
+   - Added graceful fallback when `brand_tone` column is missing
+   - The API will first try to insert with `brand_tone`, and if it fails with PGRST204, it will retry without the column
+
+2. **TypeScript Interfaces**:
+   - Made `brand_tone` optional in the `Project` interface
+   - Updated dashboard display to show "Not specified" when `brand_tone` is missing
+
+## Testing
+
+After applying the database fix:
+
+1. Try the "Generate Branding Package" feature again
+2. Verify that projects are being saved correctly
+3. Check that the dashboard displays projects properly
+
+## Prevention
+
+To prevent this issue in the future:
+
+1. Always run the complete `database-setup.sql` script when setting up a new environment
+2. Use database migrations for schema changes
+3. Consider adding schema validation checks to your deployment process
+
+## Node.js Version Warning
+
+The logs also show a Node.js deprecation warning. Consider upgrading to Node.js 20+ for better compatibility with Supabase libraries.

--- a/app/api/generate-branding/route.ts
+++ b/app/api/generate-branding/route.ts
@@ -61,18 +61,47 @@ export async function POST(request: NextRequest) {
     const brandingOutput = await getBrandingOutput(brandingInput);
 
     // Store project in database
-    const { data: project, error: projectError } = await supabase
-      .from('projects')
-      .insert({
-        user_id: userId,
-        product_name: product,
-        product_description: product, // Using product as description for now
-        target_persona: persona,
-        locality: location,
-        brand_tone: tone
-      })
-      .select()
-      .single();
+    // First try with brand_tone column
+    let project, projectError;
+    
+    try {
+      const result = await supabase
+        .from('projects')
+        .insert({
+          user_id: userId,
+          product_name: product,
+          product_description: product, // Using product as description for now
+          target_persona: persona,
+          locality: location,
+          brand_tone: tone
+        })
+        .select()
+        .single();
+      
+      project = result.data;
+      projectError = result.error;
+    } catch (error) {
+      // If brand_tone column doesn't exist, try without it
+      if (error && (error as any).code === 'PGRST204') {
+        console.log('brand_tone column not found, inserting without it');
+        const fallbackResult = await supabase
+          .from('projects')
+          .insert({
+            user_id: userId,
+            product_name: product,
+            product_description: product,
+            target_persona: persona,
+            locality: location
+          })
+          .select()
+          .single();
+        
+        project = fallbackResult.data;
+        projectError = fallbackResult.error;
+      } else {
+        throw error;
+      }
+    }
 
     if (projectError) {
       console.error('Error creating project:', projectError);

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -14,7 +14,7 @@ interface Project {
   product_name: string;
   target_persona: string;
   locality: string;
-  brand_tone: string;
+  brand_tone?: string; // Optional in case column doesn't exist yet
   created_at: string;
 }
 
@@ -182,7 +182,7 @@ export default function Dashboard() {
                             <span className="font-medium">Location:</span> {project.locality}
                           </div>
                           <div>
-                            <span className="font-medium">Tone:</span> {project.brand_tone}
+                            <span className="font-medium">Tone:</span> {project.brand_tone || 'Not specified'}
                           </div>
                         </div>
                         <p className="text-xs text-gray-500 mt-2">

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -22,7 +22,7 @@ export interface Project {
   product_description: string;
   target_persona: string;
   locality: string;
-  brand_tone: string;
+  brand_tone?: string; // Optional in case column doesn't exist yet
   created_at: string;
 }
 


### PR DESCRIPTION
Fixes 'generate branding package' failure by handling missing `brand_tone` column in database and providing a schema fix guide.

---
<a href="https://cursor.com/background-agent?bcId=bc-892e9b6f-3065-40d1-aa61-8a2864b7285a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-892e9b6f-3065-40d1-aa61-8a2864b7285a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

