### PR TITLE
Investigate branding generation failure

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -70,7 +70,12 @@ export default function Dashboard() {
       });
 
       if (!response.ok) {
-        throw new Error('Failed to generate branding');
+        let serverDetails = '';
+        try {
+          const errJson = await response.json();
+          serverDetails = errJson?.details || errJson?.error || JSON.stringify(errJson);
+        } catch {}
+        throw new Error(`Failed to generate branding (HTTP ${response.status})${serverDetails ? `: ${serverDetails}` : ''}`);
       }
 
       const result = await response.json();
@@ -78,7 +83,7 @@ export default function Dashboard() {
       await fetchProjects(); // Refresh projects list
     } catch (error) {
       console.error('Error generating branding:', error);
-      alert('Failed to generate branding. Please try again.');
+      alert(String(error));
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
Improve branding generation error handling to surface server details and gracefully handle missing `brand_tone` column.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6cf2151-8d3e-438d-a2aa-0afeab4b0a37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c6cf2151-8d3e-438d-a2aa-0afeab4b0a37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

